### PR TITLE
feat: speed up scalafix

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -35,6 +35,6 @@
   stages: [pre-commit,pre-push]
   language: python
   entry: sbt-scalafix
-  pass_filenames: true
+  pass_filenames: false
   always_run: true
   minimum_pre_commit_version: '4.0.0'

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -35,6 +35,6 @@
   stages: [pre-commit,pre-push]
   language: python
   entry: sbt-scalafix
-  pass_filenames: false
+  pass_filenames: true
   always_run: true
   minimum_pre_commit_version: '4.0.0'

--- a/README.md
+++ b/README.md
@@ -62,3 +62,28 @@ repos:
     -   id: sbt-fatal-warnings
         stages: [pre-push] #or [pre-commit, pre-push] etc.
 ```
+### ScalaFmt Hook
+
+To run scalafmt hook, your project needs to have sbt-scalafmt plugin installed.
+
+### ScalaFix Hook
+
+To run scalafix hook, your project needs to have sbt-scalafix plugin installed.
+
+In addition to enable running scalafix on all files, semanticDB needs to be enabled in your build file.
+
+This can be done by adding the following to your build file:
+
+```scala
+
+inThisBuild(
+  List(
+    semanticdbEnabled := true,
+    semanticdbVersion := scalafixSemanticdb.revision
+  )
+)
+
+ThisBuild / scalacOptions ++= Seq(
+  "-Ywarn-unused-import"
+)
+```

--- a/pre_commit_hooks/sbt_scalafix.py
+++ b/pre_commit_hooks/sbt_scalafix.py
@@ -2,8 +2,8 @@ import sys
 from pre_commit_hooks.runner import run_sbt_command
 from colorama import init as colorama_init, Fore
 
-TASK_SCALAFIX = 'scalafixAll --diff' # this one changes the files
-TASK_SCALAFIX_CHECK = 'scalafixAll --check'
+TASK_SCALAFIX = 'scalafix --files' # this one changes the files
+TASK_SCALAFIX_CHECK = 'scalafix --check --files'
 MISSING_PLUGIN_CHECK_STRING = 'Not a valid key: scalafix'
 MISSING_PLUGIN_ERROR_MSG = f'{Fore.RED}ERROR: Scalafix SBT plugin not present! See {Fore.BLUE}https://scalacenter.github.io/scalafix/docs/users/installation.html{Fore.RED} for installation instructions.'
 SCALAC_OPTIONS = 'set scalacOptions ++= Seq("-Ywarn-unused-import")'

--- a/pre_commit_hooks/sbt_scalafix.py
+++ b/pre_commit_hooks/sbt_scalafix.py
@@ -6,13 +6,11 @@ TASK_SCALAFIX = 'scalafixAll' # this one changes the files
 TASK_SCALAFIX_CHECK = 'scalafixAll --check'
 MISSING_PLUGIN_CHECK_STRING = 'Not a valid key: scalafix'
 MISSING_PLUGIN_ERROR_MSG = f'{Fore.RED}ERROR: Scalafix SBT plugin not present! See {Fore.BLUE}https://scalacenter.github.io/scalafix/docs/users/installation.html{Fore.RED} for installation instructions.'
-SCALAC_OPTIONS = 'set scalacOptions ++= Seq("-Ywarn-unused-import")'
-SCALAFIX_ENABLE = 'scalafixEnable'
 
 def main(argv=None):
     colorama_init()
-    check_exit_code = run_sbt_command(f'; {SCALAC_OPTIONS} ; {SCALAFIX_ENABLE} ; {TASK_SCALAFIX_CHECK}', MISSING_PLUGIN_CHECK_STRING, MISSING_PLUGIN_ERROR_MSG)
-    format_exit_code = run_sbt_command(f'; {SCALAC_OPTIONS} ; {SCALAFIX_ENABLE} ; {TASK_SCALAFIX}', MISSING_PLUGIN_CHECK_STRING, MISSING_PLUGIN_ERROR_MSG)
+    check_exit_code = run_sbt_command(f'; {TASK_SCALAFIX_CHECK}', MISSING_PLUGIN_CHECK_STRING, MISSING_PLUGIN_ERROR_MSG)
+    format_exit_code = run_sbt_command(f'; {TASK_SCALAFIX}', MISSING_PLUGIN_CHECK_STRING, MISSING_PLUGIN_ERROR_MSG)
     return check_exit_code + format_exit_code
 
 if __name__ == '__main__':

--- a/pre_commit_hooks/sbt_scalafix.py
+++ b/pre_commit_hooks/sbt_scalafix.py
@@ -20,7 +20,7 @@ def main(argv=None):
         return 0
     file_list = ' '.join(scala_files)
     check_exit_code = run_sbt_command(f'; clean ;  {SCALAC_OPTIONS} ; {SCALAFIX_ENABLE} ; {TASK_SCALAFIX_CHECK} {file_list}', MISSING_PLUGIN_CHECK_STRING, MISSING_PLUGIN_ERROR_MSG)
-    format_exit_code = run_sbt_command(f'; clean ;  {SCALAC_OPTIONS} ; {SCALAFIX_ENABLE} ; {TASK_SCALAFIX} {file_list}', MISSING_PLUGIN_CHECK_STRING, MISSING_PLUGIN_ERROR_MSG)
+    format_exit_code = run_sbt_command(f';  {SCALAC_OPTIONS} ; {SCALAFIX_ENABLE} ; {TASK_SCALAFIX} {file_list}', MISSING_PLUGIN_CHECK_STRING, MISSING_PLUGIN_ERROR_MSG)
     return check_exit_code + format_exit_code
 
 if __name__ == '__main__':

--- a/pre_commit_hooks/sbt_scalafix.py
+++ b/pre_commit_hooks/sbt_scalafix.py
@@ -1,7 +1,8 @@
+import sys
 from pre_commit_hooks.runner import run_sbt_command
 from colorama import init as colorama_init, Fore
 
-TASK_SCALAFIX = 'scalafixAll' # this one changes the files
+TASK_SCALAFIX = 'scalafixAll --diff' # this one changes the files
 TASK_SCALAFIX_CHECK = 'scalafixAll --check'
 MISSING_PLUGIN_CHECK_STRING = 'Not a valid key: scalafix'
 MISSING_PLUGIN_ERROR_MSG = f'{Fore.RED}ERROR: Scalafix SBT plugin not present! See {Fore.BLUE}https://scalacenter.github.io/scalafix/docs/users/installation.html{Fore.RED} for installation instructions.'
@@ -9,9 +10,17 @@ SCALAC_OPTIONS = 'set scalacOptions ++= Seq("-Ywarn-unused-import")'
 SCALAFIX_ENABLE = 'scalafixEnable'
 
 def main(argv=None):
+
+    argv = argv or sys.argv[1:]
     colorama_init()
-    check_exit_code = run_sbt_command(f'; clean ;  {SCALAC_OPTIONS} ; {SCALAFIX_ENABLE} ; {TASK_SCALAFIX_CHECK}', MISSING_PLUGIN_CHECK_STRING, MISSING_PLUGIN_ERROR_MSG)
-    format_exit_code = run_sbt_command(f'; clean ;  {SCALAC_OPTIONS} ; {SCALAFIX_ENABLE} ; {TASK_SCALAFIX}', MISSING_PLUGIN_CHECK_STRING, MISSING_PLUGIN_ERROR_MSG)
+
+    scala_files = [file for file in argv if file.endswith(".scala")]
+    if not scala_files:
+        print(f"{Fore.YELLOW}No Scala files to process.")
+        return 0
+    file_list = ' '.join(scala_files)
+    check_exit_code = run_sbt_command(f'; clean ;  {SCALAC_OPTIONS} ; {SCALAFIX_ENABLE} ; {TASK_SCALAFIX_CHECK} {file_list}', MISSING_PLUGIN_CHECK_STRING, MISSING_PLUGIN_ERROR_MSG)
+    format_exit_code = run_sbt_command(f'; clean ;  {SCALAC_OPTIONS} ; {SCALAFIX_ENABLE} ; {TASK_SCALAFIX} {file_list}', MISSING_PLUGIN_CHECK_STRING, MISSING_PLUGIN_ERROR_MSG)
     return check_exit_code + format_exit_code
 
 if __name__ == '__main__':

--- a/pre_commit_hooks/sbt_scalafix.py
+++ b/pre_commit_hooks/sbt_scalafix.py
@@ -1,4 +1,3 @@
-import sys
 from pre_commit_hooks.runner import run_sbt_command
 from colorama import init as colorama_init, Fore
 

--- a/pre_commit_hooks/sbt_scalafix.py
+++ b/pre_commit_hooks/sbt_scalafix.py
@@ -2,25 +2,17 @@ import sys
 from pre_commit_hooks.runner import run_sbt_command
 from colorama import init as colorama_init, Fore
 
-TASK_SCALAFIX = 'scalafix --files' # this one changes the files
-TASK_SCALAFIX_CHECK = 'scalafix --check --files'
+TASK_SCALAFIX = 'scalafixAll' # this one changes the files
+TASK_SCALAFIX_CHECK = 'scalafixAll --check'
 MISSING_PLUGIN_CHECK_STRING = 'Not a valid key: scalafix'
 MISSING_PLUGIN_ERROR_MSG = f'{Fore.RED}ERROR: Scalafix SBT plugin not present! See {Fore.BLUE}https://scalacenter.github.io/scalafix/docs/users/installation.html{Fore.RED} for installation instructions.'
 SCALAC_OPTIONS = 'set scalacOptions ++= Seq("-Ywarn-unused-import")'
 SCALAFIX_ENABLE = 'scalafixEnable'
 
 def main(argv=None):
-
-    argv = argv or sys.argv[1:]
     colorama_init()
-
-    scala_files = [file for file in argv if file.endswith(".scala")]
-    if not scala_files:
-        print(f"{Fore.YELLOW}No Scala files to process.")
-        return 0
-    file_list = ' '.join(scala_files)
-    check_exit_code = run_sbt_command(f'; clean ;  {SCALAC_OPTIONS} ; {SCALAFIX_ENABLE} ; {TASK_SCALAFIX_CHECK} {file_list}', MISSING_PLUGIN_CHECK_STRING, MISSING_PLUGIN_ERROR_MSG)
-    format_exit_code = run_sbt_command(f';  {SCALAC_OPTIONS} ; {SCALAFIX_ENABLE} ; {TASK_SCALAFIX} {file_list}', MISSING_PLUGIN_CHECK_STRING, MISSING_PLUGIN_ERROR_MSG)
+    check_exit_code = run_sbt_command(f'; {SCALAC_OPTIONS} ; {SCALAFIX_ENABLE} ; {TASK_SCALAFIX_CHECK}', MISSING_PLUGIN_CHECK_STRING, MISSING_PLUGIN_ERROR_MSG)
+    format_exit_code = run_sbt_command(f'; {SCALAC_OPTIONS} ; {SCALAFIX_ENABLE} ; {TASK_SCALAFIX}', MISSING_PLUGIN_CHECK_STRING, MISSING_PLUGIN_ERROR_MSG)
     return check_exit_code + format_exit_code
 
 if __name__ == '__main__':


### PR DESCRIPTION
# PR Description

## Issue / Motivation

Scalafix pre-commit hook was talking too long. It was running clean on both tasks and enabling semanticdb each time.

Clean was removed and the requirement for enabling semanticdb added to readme - it now needs to be added in the project build.sbt file instead.

This is better anyways, as it allows the user to run scalafix on their own, and not only with pre-commit hooks.

## Changes

This PR is implementing the following changes:

1. Remove clean, scalafixEnable and scalac options from the hook
2. Add an explanation to the readme about necessary build.sbt configs to use the scalafix hook

